### PR TITLE
Fix Cloudfront routes.

### DIFF
--- a/infrastructure/secure_s3_site/cdn.tf
+++ b/infrastructure/secure_s3_site/cdn.tf
@@ -6,7 +6,7 @@ resource "aws_cloudfront_distribution" "redirect_all_requests_to_www" {
     custom_origin_config {
       http_port = 80
       https_port = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols = ["TLSv1.2"]
     }
   }
@@ -58,7 +58,7 @@ resource "aws_cloudfront_distribution" "static_host_bucket" {
     custom_origin_config {
       http_port = 80
       https_port = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols = ["TLSv1.2"]
     }
   }

--- a/infrastructure/secure_s3_site/dns.tf
+++ b/infrastructure/secure_s3_site/dns.tf
@@ -14,10 +14,6 @@ resource "aws_route53_record" "www" {
   zone_id = "${var.hosted_zone_id}"
   name = "www.${var.domain}"
   type = "CNAME"
-
-  alias {
-    name = "${aws_cloudfront_distribution.static_host_bucket.domain_name}"
-    zone_id = "${aws_cloudfront_distribution.static_host_bucket.hosted_zone_id}"
-    evaluate_target_health = false
-  }
+  ttl = "3600"
+  records = ["${aws_cloudfront_distribution.static_host_bucket.domain_name}"]
 }


### PR DESCRIPTION
The S3 buckets only reply at these endpoints over HTTP; alias records don’t seem to be working on Route53.